### PR TITLE
Feature/dr 7735 development convenience

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,7 @@ group :development, :test do
   gem 'jekyll-sitemap', '~> 1.0.0'
   gem 'scss_lint', '~> 0.52.0'
 end
+
+group :jekyll_plugins do
+  gem 'hawkins'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,5 @@ group :development, :test do
 end
 
 group :jekyll_plugins do
-  gem 'hawkins'
+  gem 'jekyll-livereload'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,8 +4,16 @@ GEM
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
     colorator (1.1.0)
+    em-websocket (0.5.1)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0.6.0)
+    eventmachine (1.2.3)
     ffi (1.9.17)
     forwardable-extended (2.6.0)
+    hawkins (2.0.5)
+      em-websocket (~> 0.5)
+      jekyll (~> 3.1)
+    http_parser.rb (0.6.0)
     jekyll (3.4.0)
       addressable (~> 2.4)
       colorator (~> 1.0)
@@ -49,10 +57,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  hawkins
   jekyll (~> 3.4.0)
   jekyll-redirect-from (~> 0.12.1)
   jekyll-sitemap (~> 1.0.0)
   scss_lint (~> 0.52.0)
 
 BUNDLED WITH
-   1.13.6
+   1.14.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,9 +10,6 @@ GEM
     eventmachine (1.2.3)
     ffi (1.9.17)
     forwardable-extended (2.6.0)
-    hawkins (2.0.5)
-      em-websocket (~> 0.5)
-      jekyll (~> 3.1)
     http_parser.rb (0.6.0)
     jekyll (3.4.0)
       addressable (~> 2.4)
@@ -25,6 +22,9 @@ GEM
       pathutil (~> 0.9)
       rouge (~> 1.7)
       safe_yaml (~> 1.0)
+    jekyll-livereload (0.2.2)
+      em-websocket (~> 0.5)
+      jekyll (~> 3.0)
     jekyll-redirect-from (0.12.1)
       jekyll (~> 3.3)
     jekyll-sass-converter (1.5.0)
@@ -57,8 +57,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  hawkins
   jekyll (~> 3.4.0)
+  jekyll-livereload
   jekyll-redirect-from (~> 0.12.1)
   jekyll-sitemap (~> 1.0.0)
   scss_lint (~> 0.52.0)

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -149,17 +149,13 @@ module.exports = function (grunt) {
     },
 
     watch: {
-      src: {
-        files: '<%= concat.bootstrap.src %>',
-        tasks: ['babel:dev']
-      },
       sass: {
         files: 'scss/**/*.scss',
-        tasks: ['dist-css', 'docs']
+        tasks: ['sass-compile', 'docs-css', 'copy:docs']
       },
       docs: {
         files: 'docs/assets/scss/**/*.scss',
-        tasks: ['dist-css', 'docs']
+        tasks: ['sass-compile', 'docs-css', 'copy:docs']
       }
     },
 

--- a/docs/_layouts/docs.html
+++ b/docs/_layouts/docs.html
@@ -15,7 +15,6 @@
     <div class="bd-pageheader">
       <div class="container">
         {% include page-headers.html %}
-        {% include ads.html %}
       </div>
     </div>
 

--- a/docs/_layouts/simple.html
+++ b/docs/_layouts/simple.html
@@ -8,7 +8,6 @@ layout: default
     <p class="lead">
       Quickly get a project started with any of our examples ranging from using parts of the framework to custom components and layouts.
     </p>
-    {% include ads.html %}
   </div>
 </div>
 

--- a/docs/getting-started/build-tools.md
+++ b/docs/getting-started/build-tools.md
@@ -57,12 +57,11 @@ Learn more about using Jekyll by reading its [documentation](https://jekyllrb.co
 
 ### Live reloading during development
 
-Running the documentation locally with development convenience is using the [Hawkins Plugin](https://github.com/awood/hawkins) for Jekyll as well as a grunt watch task. To get started:
+Running the documentation locally with development convenience is using the [jekyll-livereload](https://github.com/RobertDeRose/jekyll-livereload) plugin for Jekyll as well as a grunt watch task. To get started:
 
 1.  Run through the [tooling setup](#tooling-setup) above to install Jekyll (the site builder) and other Ruby dependencies with `bundle install`.
-2.  From the root `/bootstrap` directory, run `bundle exec jekyll liveserve` in the command line.
-3.  From the root `/bootstrap` directory, run `grunt watch` in the command line.
-4.  Open <http://localhost:9001> in your browser, and voilà.
+2.  From the root `/bootstrap` directory, run `npm run dev` in the command line.
+3.  Open <http://localhost:9001> in your browser, and voilà.
 
 ## Troubleshooting
 

--- a/docs/getting-started/build-tools.md
+++ b/docs/getting-started/build-tools.md
@@ -55,6 +55,15 @@ Running our documentation locally requires the use of Jekyll, a decently flexibl
 
 Learn more about using Jekyll by reading its [documentation](https://jekyllrb.com/docs/home/).
 
+### Live reloading during development
+
+Running the documentation locally with development convenience is using the [Hawkins Plugin](https://github.com/awood/hawkins) for Jekyll as well as a grunt watch task. To get started:
+
+1.  Run through the [tooling setup](#tooling-setup) above to install Jekyll (the site builder) and other Ruby dependencies with `bundle install`.
+2.  From the root `/bootstrap` directory, run `bundle exec jekyll liveserve` in the command line.
+3.  From the root `/bootstrap` directory, run `grunt watch` in the command line.
+4.  Open <http://localhost:9001> in your browser, and voilà.
+
 ## Troubleshooting
 
 Should you encounter problems with installing dependencies or running Grunt commands, uninstall all previous dependency versions (global and local). Then, rerun `npm install`.

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,7 +10,6 @@ layout: home
       <a href="{{ site.baseurl }}/getting-started/download/" class="btn btn-lg" onclick="ga('send', 'event', 'Jumbotron actions', 'Download', 'Download {{ site.current_version }}');">Download Bootstrap</a>
     </p>
     <p class="version">Currently v{{ site.current_version }}</p>
-    {% include ads.html %}
   </div>
 </main>
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "update-shrinkwrap": "npm shrinkwrap --dev && shx mv ./npm-shrinkwrap.json ./grunt/npm-shrinkwrap.json",
     "test": "npm run eslint && grunt test",
     "dist-n-push": "grunt dist && git add dist docs && git commit -m 'Version bump' && git push --follow-tags",
-    "release": "npm version prerelease && npm run dist-n-push"
+    "release": "npm version prerelease && npm run dist-n-push",
+    "dev": "concurrently -k 'bundle exec jekyll serve --livereload' 'grunt watch'"
   },
   "style": "dist/css/bootstrap.css",
   "sass": "scss/bootstrap.scss",
@@ -59,6 +60,7 @@
     "babel-plugin-transform-es2015-modules-strip": "^0.1.0",
     "babel-preset-es2015": "^6.22.0",
     "clean-css-cli": "^4.0.0",
+    "concurrently": "^3.4.0",
     "eslint": "^3.15.0",
     "grunt": "^1.0.1",
     "grunt-babel": "^6.0.0",


### PR DESCRIPTION
- Modifies the grunt watch task to make development faster
- Prepares the theme for using the provided documentation as a style guide
- Enables a live reload for jekyll for even more convenience

As we're modifying the bootstrap documentation directly we'll have to deal with merges from twb/bootstrap for future updates. Any thoughts?