### PR TITLE
Feature/dr 7753 dropdown

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -200,6 +200,9 @@ module.exports = function (grunt) {
       sass: {
         command: 'npm run sass'
       },
+      'sass-theme': {
+        command: 'npm run sass-theme'
+      },
       'sass-docs': {
         command: 'npm run sass-docs'
       },
@@ -302,7 +305,7 @@ module.exports = function (grunt) {
   grunt.registerTask('test-scss', ['exec:scss-lint'])
 
   // CSS distribution task.
-  grunt.registerTask('sass-compile', ['exec:sass', 'exec:sass-docs'])
+  grunt.registerTask('sass-compile', ['exec:sass-theme', 'exec:sass-docs'])
 
   grunt.registerTask('dist-css', ['sass-compile', 'exec:postcss', 'exec:clean-css', 'exec:clean-css-docs'])
 

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -13,9 +13,9 @@
 
 <!-- Bootstrap core CSS -->
 {% if site.github %}
-  <link href="{{ site.baseurl }}/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="{{ site.baseurl }}/dist/css/joblocal.min.css" rel="stylesheet">
 {% else %}
-  <link href="{{ site.baseurl }}/dist/css/bootstrap.css" rel="stylesheet">
+  <link href="{{ site.baseurl }}/dist/css/joblocal.css" rel="stylesheet">
 {% endif %}
 
 <!-- Documentation extras -->
@@ -24,12 +24,3 @@
 <!-- Favicons -->
 <link rel="apple-touch-icon" href="{{ site.baseurl }}/apple-touch-icon.png">
 <link rel="icon" href="{{ site.baseurl }}/favicon.ico">
-
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-  ga('create', 'UA-146052-10', 'getbootstrap.com');
-  ga('send', 'pageview');
-</script>

--- a/docs/assets/scss/_component-examples.scss
+++ b/docs/assets/scss/_component-examples.scss
@@ -307,7 +307,7 @@
   .bg-danger,
   .bg-inverse,
   .bg-faded {
-    &:not(.navbar) {
+    &:not(.navbar):not(.dropdown-menu) {
       padding: .5rem;
       margin-top: .5rem;
       margin-bottom: .5rem;

--- a/docs/components/dropdowns.md
+++ b/docs/components/dropdowns.md
@@ -480,17 +480,29 @@ Add `.disabled` to items in the dropdown to **style them as disabled**.
 
 {% example html %}
 <div class="dropdown-menu">
-  <a class="dropdown-item dropdown-item-media" href="#">
-    <img class="dropdown-item-image" data-src="holder.js/40x40" alt="Generic placeholder image">
-    <div class="dropdown-item-title">Heading</div>
+  <a class="dropdown-item" href="#">
+    <div class="media">
+      <img data-src="holder.js/40x40" alt="Generic placeholder image">
+      <div class="media-body">
+        <div class="dropdown-item-title">Heading</div>
+      </div>
+    </div>
   </a>
-  <a class="dropdown-item dropdown-item-media" href="#">
-    <img class="dropdown-item-image" data-src="holder.js/40x40" alt="Generic placeholder image">
-    <div class="dropdown-item-title">Heading</div>
+  <a class="dropdown-item" href="#">
+    <div class="media">
+      <img data-src="holder.js/40x40" alt="Generic placeholder image">
+      <div class="media-body">
+        <div class="dropdown-item-title">Heading</div>
+      </div>
+    </div>
   </a>
-  <a class="dropdown-item dropdown-item-media" href="#">
-    <img class="dropdown-item-image" data-src="holder.js/40x40" alt="Generic placeholder image">
-    <div class="dropdown-item-title">Heading</div>
+  <a class="dropdown-item" href="#">
+    <div class="media">
+      <img data-src="holder.js/40x40" alt="Generic placeholder image">
+      <div class="media-body">
+        <div class="dropdown-item-title">Heading</div>
+      </div>
+    </div>
   </a>
 </div>
 {% endexample %}
@@ -518,25 +530,31 @@ Add `.disabled` to items in the dropdown to **style them as disabled**.
 
 {% example html %}
 <div class="dropdown-menu">
-  <a class="dropdown-item dropdown-item-media" href="#">
-    <img class="dropdown-item-image" data-src="holder.js/40x40" alt="Generic placeholder image">
-    <div>
-      <div class="dropdown-item-title">Heading</div>
-      <div class="dropdown-item-subtitle">Subheading</div>
+  <a class="dropdown-item" href="#">
+    <div class="media">
+      <img data-src="holder.js/40x40" alt="Generic placeholder image">
+      <div class="media-body">
+        <div class="dropdown-item-title">Heading</div>
+        <div class="dropdown-item-subtitle">Subheading</div>
+      </div>
     </div>
   </a>
-  <a class="dropdown-item dropdown-item-media" href="#">
-    <img class="dropdown-item-image" data-src="holder.js/40x40" alt="Generic placeholder image">
-    <div>
-      <div class="dropdown-item-title">Heading</div>
-      <div class="dropdown-item-subtitle">Subheading</div>
+  <a class="dropdown-item" href="#">
+    <div class="media">
+      <img data-src="holder.js/40x40" alt="Generic placeholder image">
+      <div class="media-body">
+        <div class="dropdown-item-title">Heading</div>
+        <div class="dropdown-item-subtitle">Subheading</div>
+      </div>
     </div>
   </a>
-  <a class="dropdown-item dropdown-item-media" href="#">
-    <img class="dropdown-item-image" data-src="holder.js/40x40" alt="Generic placeholder image">
-    <div>
-      <div class="dropdown-item-title">Heading</div>
-      <div class="dropdown-item-subtitle">Subheading</div>
+  <a class="dropdown-item" href="#">
+    <div class="media">
+      <img data-src="holder.js/40x40" alt="Generic placeholder image">
+      <div class="media-body">
+        <div class="dropdown-item-title">Heading</div>
+        <div class="dropdown-item-subtitle">Subheading</div>
+      </div>
     </div>
   </a>
 </div>
@@ -545,7 +563,7 @@ Add `.disabled` to items in the dropdown to **style them as disabled**.
 ## Inverse menu
 
 {% example html %}
-<div class="dropdown-menu dropdown-menu-inverse">
+<div class="dropdown-menu dropdown-menu-inverse bg-inverse">
   <a class="dropdown-item" href="#">
     Regular link
   </a>

--- a/docs/components/dropdowns.md
+++ b/docs/components/dropdowns.md
@@ -476,6 +476,96 @@ Add `.disabled` to items in the dropdown to **style them as disabled**.
 </div>
 {% endexample %}
 
+## Menu items with media
+
+{% example html %}
+<div class="dropdown-menu">
+  <a class="dropdown-item dropdown-item-media" href="#">
+    <img class="dropdown-item-image" data-src="holder.js/40x40" alt="Generic placeholder image">
+    <div class="dropdown-item-title">Heading</div>
+  </a>
+  <a class="dropdown-item dropdown-item-media" href="#">
+    <img class="dropdown-item-image" data-src="holder.js/40x40" alt="Generic placeholder image">
+    <div class="dropdown-item-title">Heading</div>
+  </a>
+  <a class="dropdown-item dropdown-item-media" href="#">
+    <img class="dropdown-item-image" data-src="holder.js/40x40" alt="Generic placeholder image">
+    <div class="dropdown-item-title">Heading</div>
+  </a>
+</div>
+{% endexample %}
+
+## Menu items with subtitles
+
+{% example html %}
+<div class="dropdown-menu">
+  <a class="dropdown-item" href="#">
+    <div class="dropdown-item-title">Heading</div>
+    <div class="dropdown-item-subtitle">Subheading</div>
+  </a>
+  <a class="dropdown-item" href="#">
+    <div class="dropdown-item-title">Heading</div>
+    <div class="dropdown-item-subtitle">Subheading</div>
+  </a>
+  <a class="dropdown-item" href="#">
+    <div class="dropdown-item-title">Heading</div>
+    <div class="dropdown-item-subtitle">Subheading</div>
+  </a>
+</div>
+{% endexample %}
+
+## Menu items with media and subtitles
+
+{% example html %}
+<div class="dropdown-menu">
+  <a class="dropdown-item dropdown-item-media" href="#">
+    <img class="dropdown-item-image" data-src="holder.js/40x40" alt="Generic placeholder image">
+    <div>
+      <div class="dropdown-item-title">Heading</div>
+      <div class="dropdown-item-subtitle">Subheading</div>
+    </div>
+  </a>
+  <a class="dropdown-item dropdown-item-media" href="#">
+    <img class="dropdown-item-image" data-src="holder.js/40x40" alt="Generic placeholder image">
+    <div>
+      <div class="dropdown-item-title">Heading</div>
+      <div class="dropdown-item-subtitle">Subheading</div>
+    </div>
+  </a>
+  <a class="dropdown-item dropdown-item-media" href="#">
+    <img class="dropdown-item-image" data-src="holder.js/40x40" alt="Generic placeholder image">
+    <div>
+      <div class="dropdown-item-title">Heading</div>
+      <div class="dropdown-item-subtitle">Subheading</div>
+    </div>
+  </a>
+</div>
+{% endexample %}
+
+## Inverse menu
+
+{% example html %}
+<div class="dropdown-menu dropdown-menu-inverse">
+  <a class="dropdown-item" href="#">
+    Regular link
+  </a>
+  <a class="dropdown-item" href="#">
+    Another link
+  </a>
+  <a class="dropdown-item" href="#">
+    One more link
+  </a>
+  <div class="dropdown-divider"></div>
+  <h6 class="dropdown-header">Item states</h6>
+  <a class="dropdown-item disabled" href="#">
+    Disabled link
+  </a>
+  <a class="dropdown-item active" href="#">
+    Active link
+  </a>
+</div>
+{% endexample %}
+
 ## Usage
 
 Via data attributes or JavaScript, the dropdown plugin toggles hidden content (dropdown menus) by toggling the `.show` class on the parent list item.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "postcss": "postcss --config grunt/postcss.js --replace dist/css/*.css",
     "postcss-docs": "postcss --config grunt/postcss.js --no-map --replace docs/assets/css/docs.min.css && postcss --config grunt/postcss.js --no-map --replace docs/examples/**/*.css",
     "sass": "node-sass --output-style expanded --source-map true --precision 6 scss/bootstrap.scss dist/css/bootstrap.css && node-sass --output-style expanded --source-map true --precision 6 scss/bootstrap-grid.scss dist/css/bootstrap-grid.css && node-sass --output-style expanded --source-map true --precision 6 scss/bootstrap-reboot.scss dist/css/bootstrap-reboot.css",
+    "sass-theme": "node-sass --output-style expanded --source-map true --precision 6 scss/joblocal.scss dist/css/joblocal.css",
     "sass-docs": "node-sass --output-style expanded --source-map true --precision 6 docs/assets/scss/docs.scss docs/assets/css/docs.min.css",
     "scss-lint": "bundle exec scss-lint --config scss/.scss-lint.yml scss/*.scss",
     "scss-lint-docs": "bundle exec scss-lint --config scss/.scss-lint.yml --exclude docs/assets/scss/docs.scss docs/assets/scss/*.scss",

--- a/scss/_custom.scss
+++ b/scss/_custom.scss
@@ -43,3 +43,28 @@ $link-color:            $brand-info;
 $link-decoration:       none !default;
 $link-hover-color:      darken($link-color, 15%) !default;
 $link-hover-decoration: underline !default;
+
+
+// Dropdowns
+//
+// Dropdown menu container and contents.
+
+$dropdown-min-width:          15rem;
+$dropdown-padding-y:          0;
+
+$dropdown-inverse-bg:         $brand-inverse;
+$dropdown-inverse-divider-bg: lighten($dropdown-inverse-bg, 10%);
+
+$dropdown-inverse-header-color: $gray;
+
+$dropdown-inverse-link-color:       $gray-lightest;
+$dropdown-inverse-link-hover-color: lighten($gray-lightest, 10%);
+$dropdown-inverse-link-hover-bg:    $brand-primary;
+
+$dropdown-inverse-link-active-color:  $gray-lightest;
+$dropdown-inverse-link-active-bg:     $brand-primary;
+
+$dropdown-inverse-link-disabled-color: lighten($dropdown-inverse-bg, 15%);
+
+$dropdown-item-padding-x:     .75rem;
+$dropdown-item-padding-y:     .5rem;

--- a/scss/_custom.scss
+++ b/scss/_custom.scss
@@ -7,12 +7,26 @@
 //
 // Grayscale and brand colors for use across Bootstrap.
 
+// Start with assigning color names to specific hex values.
+$white:  #fff !default;
+$black:  #000 !default;
+$red:    #d9534f !default;
+$orange: #f0ad4e !default;
+$yellow: #ffd500 !default;
+$green:  #5cb85c !default;
+$blue:   #0275d8 !default;
+$teal:   #5bc0de !default;
+$pink:   #ff5b77 !default;
+$purple: #613d7c !default;
+
+// Create grayscale
 $gray-dark:     #444547;
 $gray:          #969696;
 $gray-light:    #cccccc;
 $gray-lighter:  #d7d7d7;
 $gray-lightest: #f6f6f6;
 
+// Reassign color vars to semantic color scheme
 $brand-primary: #f8ae00;
 $brand-success: #21ba45;
 $brand-info:    #2185d0;
@@ -20,13 +34,19 @@ $brand-warning: #f8ae00;
 $brand-danger:  #db2828;
 $brand-inverse: #444547;
 
+
 // Options
 //
 // Quickly modify global styling by enabling or disabling optional features.
 
-$enable-flex:               true;
+$enable-rounded:            true !default;
 $enable-shadows:            true;
-$enable-transitions:        true;
+$enable-gradients:          false !default;
+$enable-transitions:        true !default;
+$enable-hover-media-query:  false !default;
+$enable-grid-classes:       true !default;
+$enable-print-styles:       true !default;
+
 
 // Body
 //
@@ -34,6 +54,7 @@ $enable-transitions:        true;
 
 $body-bg:       $gray-lightest;
 $body-color:    $gray-dark;
+
 
 // Links
 //
@@ -45,26 +66,100 @@ $link-hover-color:      darken($link-color, 15%) !default;
 $link-hover-decoration: underline !default;
 
 
+// Spacing
+//
+// Control the default styling of most Bootstrap elements by modifying these
+// variables. Mostly focused on spacing.
+// You can add more entries to the $spacers map, should you need more variation.
+
+$spacer:   1rem !default;
+$spacer-x: $spacer !default;
+$spacer-y: $spacer !default;
+$spacers: (
+  0: (
+    x: 0,
+    y: 0
+  ),
+  1: (
+    x: ($spacer-x * .25),
+    y: ($spacer-y * .25)
+  ),
+  2: (
+    x: ($spacer-x * .5),
+    y: ($spacer-y * .5)
+  ),
+  3: (
+    x: $spacer-x,
+    y: $spacer-y
+  ),
+  4: (
+    x: ($spacer-x * 1.5),
+    y: ($spacer-y * 1.5)
+  ),
+  5: (
+    x: ($spacer-x * 3),
+    y: ($spacer-y * 3)
+  )
+) !default;
+$border-width: 1px !default;
+
+
+// Components
+//
+// Define common padding and border radius sizes and more.
+
+$line-height-lg:         (4 / 3) !default;
+$line-height-sm:         1.5 !default;
+
+$border-radius:          .25rem !default;
+$border-radius-lg:       .3rem !default;
+$border-radius-sm:       .2rem !default;
+
+$component-active-color: $white !default;
+$component-active-bg:    $brand-primary !default;
+$component-inverse-bg:   $brand-inverse;
+
+$caret-width:            .3em !default;
+
+$transition-base:        all .2s ease-in-out !default;
+$transition-fade:        opacity .15s linear !default;
+$transition-collapse:    height .35s ease !default;
+
+
 // Dropdowns
 //
 // Dropdown menu container and contents.
 
-$dropdown-min-width:          15rem;
-$dropdown-padding-y:          0;
+$dropdown-min-width:              15rem;
+$dropdown-padding-y:              0;
+$dropdown-margin-top:             .125rem !default;
+$dropdown-bg:                     $white !default;
+$dropdown-border-color:           rgba($black,.15) !default;
+$dropdown-border-width:           $border-width !default;
+$dropdown-divider-bg:             $gray-lighter !default;
+$dropdown-box-shadow:             0 .5rem 1rem rgba($black,.175) !default;
 
-$dropdown-inverse-bg:         $brand-inverse;
-$dropdown-inverse-divider-bg: lighten($dropdown-inverse-bg, 10%);
+$dropdown-link-color:             $gray-dark !default;
+$dropdown-link-hover-color:       darken($gray-dark, 5%) !default;
+$dropdown-link-hover-bg:          $gray-lightest !default;
 
-$dropdown-inverse-header-color: $gray;
+$dropdown-link-active-color:      $component-active-color !default;
+$dropdown-link-active-bg:         $component-active-bg !default;
 
-$dropdown-inverse-link-color:       $gray-lightest;
-$dropdown-inverse-link-hover-color: lighten($gray-lightest, 10%);
-$dropdown-inverse-link-hover-bg:    $brand-primary;
+$dropdown-link-disabled-color:    $gray-light !default;
 
-$dropdown-inverse-link-active-color:  $gray-lightest;
-$dropdown-inverse-link-active-bg:     $brand-primary;
+$dropdown-item-padding-x:         .75rem;
+$dropdown-item-padding-y:         .5rem;
 
-$dropdown-inverse-link-disabled-color: lighten($dropdown-inverse-bg, 15%);
+$dropdown-header-color:           $gray-light !default;
 
-$dropdown-item-padding-x:     .75rem;
-$dropdown-item-padding-y:     .5rem;
+$dropdown-inverse-divider-bg:           lighten($component-inverse-bg, 10%);
+$dropdown-inverse-header-color:         $gray;
+
+$dropdown-inverse-link-color:           $gray-lightest;
+$dropdown-inverse-link-hover-color:     lighten($gray-lightest, 10%);
+$dropdown-inverse-link-hover-bg:        $component-active-bg;
+
+$dropdown-inverse-link-active-color:    $gray-lightest;
+$dropdown-inverse-link-active-bg:       $component-active-bg;
+$dropdown-inverse-link-disabled-color:  lighten($component-inverse-bg, 15%);

--- a/scss/custom/_dropdown.scss
+++ b/scss/custom/_dropdown.scss
@@ -1,0 +1,58 @@
+.dropdown-item {
+  padding: $dropdown-item-padding-y $dropdown-item-padding-x;
+
+  .dropdown-item-title {
+    font-weight: $font-weight-bold;
+  }
+
+  .dropdown-item-subtitle {
+    font-size: $small-font-size;
+  }
+}
+
+.dropdown-header {
+  text-transform: uppercase;
+}
+
+.dropdown-item-media {
+  display: flex;
+  flex-flow: row;
+  align-items: center;
+}
+
+.dropdown-item-image {
+  margin-right: .5rem;
+}
+
+.dropdown-menu-inverse {
+  background-color: $dropdown-inverse-bg;
+
+  .dropdown-header {
+    color: $dropdown-inverse-header-color;
+  }
+
+  .dropdown-divider {
+    @include nav-divider($dropdown-inverse-divider-bg);
+  }
+
+  .dropdown-item {
+    color: $dropdown-inverse-link-color;
+
+    @include hover-focus {
+      color: $dropdown-inverse-link-hover-color;
+      background-color: $dropdown-inverse-link-hover-bg;
+    }
+
+    &.active,
+    &:active {
+      color: $dropdown-inverse-link-active-color;
+      background-color: $dropdown-inverse-link-active-bg;
+    }
+
+    &.disabled,
+    &:disabled {
+      color: $dropdown-inverse-link-disabled-color;
+      background-color: transparent;
+    }
+  }
+}

--- a/scss/custom/_dropdown.scss
+++ b/scss/custom/_dropdown.scss
@@ -14,19 +14,11 @@
   text-transform: uppercase;
 }
 
-.dropdown-item-media {
-  display: flex;
-  flex-flow: row;
-  align-items: center;
-}
-
 .dropdown-item-image {
   margin-right: .5rem;
 }
 
 .dropdown-menu-inverse {
-  background-color: $dropdown-inverse-bg;
-
   .dropdown-header {
     color: $dropdown-inverse-header-color;
   }

--- a/scss/joblocal.scss
+++ b/scss/joblocal.scss
@@ -1,0 +1,5 @@
+// import bootstrap components
+@import "bootstrap";
+
+// import custom components
+@import "custom/_dropdown";


### PR DESCRIPTION
Adds the styles we need for our dropdown modifications, in order to overwrite bootstraps dropdowns and add new functionality I had to introduce a similar theming system as in bootstrap v3. This change is open for discussion.

- The entrypoint for styles is [scss/joblocal.scss](https://github.com/joblocal/bootstrap/compare/joblocal-bootstrap4...joblocal:feature/DR-7753-dropdown?expand=1#diff-a6f6bd4bda80082b88d38caf22828fee)
- A new sass compile script was added to [package.json](https://github.com/joblocal/bootstrap/compare/joblocal-bootstrap4...joblocal:feature/DR-7753-dropdown?expand=1#diff-b9cfc7f2cdf78a7f4b91a753d10865a2) "sass-theme"
- The sass-theme script is used by "grunt watch" and builds dist/css/joblocal.css
- [joblocal.css is included in the docs](https://github.com/joblocal/bootstrap/compare/joblocal-bootstrap4...joblocal:feature/DR-7753-dropdown?expand=1#diff-5b932442d33c890bd078cacc572f320f) and thus allows the modification of preexisting bootstrap components like "dropdown-menu"