### PR TITLE
DR-10275-remove-render-blocking-webfont

### DIFF
--- a/scss/joblocal.scss
+++ b/scss/joblocal.scss
@@ -1,6 +1,3 @@
-// Adds Webfont
-@import url('https://fonts.googleapis.com/css?family=Fira+Sans:200,400,400i,600,600i');
-
 // import bootstrap components
 @import "bootstrap";
 


### PR DESCRIPTION
In order to remove render blocking stuff from our theme I'd like to remove the font import statement from the bootstrap repo and let the project using the theme worry about how to import the font.